### PR TITLE
squid:S1213 - The members of an interface declaration or class should…

### DIFF
--- a/library/src/main/java/de/mrapp/android/bottomsheet/BottomSheet.java
+++ b/library/src/main/java/de/mrapp/android/bottomsheet/BottomSheet.java
@@ -83,7 +83,23 @@ import static de.mrapp.android.util.DisplayUtil.getOrientation;
  * @author Michael Rapp
  * @since 1.0.0
  */
-public class BottomSheet extends Dialog implements DialogInterface, DraggableView.Callback {
+    public class BottomSheet extends Dialog implements DialogInterface, DraggableView.Callback {
+
+    /**
+     * Creates a bottom sheet, which is designed according to Android 5's Material Design guidelines
+     * even on pre-Lollipop devices.
+     *
+     * @param context
+     *         The context, which should be used by the bottom sheet, as an instance of the class
+     *         {@link Context}. The context may not be null
+     * @param themeResourceId
+     *         The resource id of the theme, which should be used by the bottom sheet, as an {@link
+     *         Integer} value. The resource id must correspond to a valid theme
+     */
+    protected BottomSheet(@NonNull final Context context, @StyleRes final int themeResourceId) {
+        super(context, themeResourceId);
+        initialize();
+    }
 
     /**
      * A builder, which allows to create and show bottom sheets, which are designed according to
@@ -98,6 +114,33 @@ public class BottomSheet extends Dialog implements DialogInterface, DraggableVie
          * The bottom sheet, which is created by the builder.
          */
         private BottomSheet bottomSheet;
+
+        /**
+         * Creates a new builder, which allows to create bottom sheets, which are designed according
+         * to Android 5's Material Design guidelines even on pre-Lollipop devices.
+         *
+         * @param context
+         *         The context, which should be used by the builder, as an instance of the class
+         *         {@link Context}. The context may not be null
+         */
+        public Builder(@NonNull final Context context) {
+            this(context, -1);
+        }
+
+        /**
+         * Creates a new builder, which allows to create bottom sheets, which are designed according
+         * to Android 5's Material Design guidelines even on pre-Lollipop devices.
+         *
+         * @param context
+         *         The context, which should be used by the builder, as an instance of the class
+         *         {@link Context}. The context may not be null
+         * @param themeResourceId
+         *         The resource id of the theme, which should be used by the bottom sheet, as an
+         *         {@link Integer} value. The resource id must correspond to a valid theme
+         */
+        public Builder(@NonNull final Context context, @StyleRes final int themeResourceId) {
+            initialize(context, themeResourceId);
+        }
 
         /**
          * Initializes the builder.
@@ -252,33 +295,6 @@ public class BottomSheet extends Dialog implements DialogInterface, DraggableVie
             if (dragSensitivity != -1) {
                 setDragSensitivity(dragSensitivity);
             }
-        }
-
-        /**
-         * Creates a new builder, which allows to create bottom sheets, which are designed according
-         * to Android 5's Material Design guidelines even on pre-Lollipop devices.
-         *
-         * @param context
-         *         The context, which should be used by the builder, as an instance of the class
-         *         {@link Context}. The context may not be null
-         */
-        public Builder(@NonNull final Context context) {
-            this(context, -1);
-        }
-
-        /**
-         * Creates a new builder, which allows to create bottom sheets, which are designed according
-         * to Android 5's Material Design guidelines even on pre-Lollipop devices.
-         *
-         * @param context
-         *         The context, which should be used by the builder, as an instance of the class
-         *         {@link Context}. The context may not be null
-         * @param themeResourceId
-         *         The resource id of the theme, which should be used by the bottom sheet, as an
-         *         {@link Integer} value. The resource id must correspond to a valid theme
-         */
-        public Builder(@NonNull final Context context, @StyleRes final int themeResourceId) {
-            initialize(context, themeResourceId);
         }
 
         /**
@@ -1458,22 +1474,6 @@ public class BottomSheet extends Dialog implements DialogInterface, DraggableVie
         if (maximizeListener != null) {
             maximizeListener.onMaximize(this);
         }
-    }
-
-    /**
-     * Creates a bottom sheet, which is designed according to Android 5's Material Design guidelines
-     * even on pre-Lollipop devices.
-     *
-     * @param context
-     *         The context, which should be used by the bottom sheet, as an instance of the class
-     *         {@link Context}. The context may not be null
-     * @param themeResourceId
-     *         The resource id of the theme, which should be used by the bottom sheet, as an {@link
-     *         Integer} value. The resource id must correspond to a valid theme
-     */
-    protected BottomSheet(@NonNull final Context context, @StyleRes final int themeResourceId) {
-        super(context, themeResourceId);
-        initialize();
     }
 
     /**

--- a/library/src/main/java/de/mrapp/android/bottomsheet/adapter/DividableGridAdapter.java
+++ b/library/src/main/java/de/mrapp/android/bottomsheet/adapter/DividableGridAdapter.java
@@ -55,6 +55,36 @@ import static de.mrapp.android.util.DisplayUtil.getOrientation;
 public class DividableGridAdapter extends BaseAdapter {
 
     /**
+     * Creates a new adapter, which manages the items of a {@link BottomSheet}.
+     *
+     * @param context
+     *         The context, which should be used by the adapter, as an instance of the class {@link
+     *         Context}. The context may not be null
+     * @param style
+     *         The style, which should be used to display the adapter's items, as a value of the
+     *         enum {@link Style}. The style may either be <code>LIST</code>,
+     *         <code>LIST_COLUMNS</code> or <code>GRID</code>
+     * @param width
+     *         The width of the bottom sheet, the items, which are displayed by the adapter, belong
+     *         to, as an {@link Integer} value
+     */
+    public DividableGridAdapter(@NonNull final Context context, final Style style,
+                                final int width) {
+        ensureNotNull(context, "The context may not be null");
+        ensureNotNull(style, "The style may not be null");
+        this.context = context;
+        this.style = style;
+        this.items = new ArrayList<>();
+        this.rawItems = null;
+        this.iconCount = 0;
+        this.dividerCount = 0;
+        this.notifyOnChange = true;
+        this.itemColor = -1;
+        this.dividerColor = -1;
+        setWidth(width);
+    }
+
+    /**
      * The view holder, which is used to visualize items.
      */
     private static class ItemViewHolder {
@@ -337,36 +367,6 @@ public class DividableGridAdapter extends BaseAdapter {
             viewHolder.leftDivider.setBackgroundColor(dividerColor);
             viewHolder.rightDivider.setBackgroundColor(dividerColor);
         }
-    }
-
-    /**
-     * Creates a new adapter, which manages the items of a {@link BottomSheet}.
-     *
-     * @param context
-     *         The context, which should be used by the adapter, as an instance of the class {@link
-     *         Context}. The context may not be null
-     * @param style
-     *         The style, which should be used to display the adapter's items, as a value of the
-     *         enum {@link Style}. The style may either be <code>LIST</code>,
-     *         <code>LIST_COLUMNS</code> or <code>GRID</code>
-     * @param width
-     *         The width of the bottom sheet, the items, which are displayed by the adapter, belong
-     *         to, as an {@link Integer} value
-     */
-    public DividableGridAdapter(@NonNull final Context context, final Style style,
-                                final int width) {
-        ensureNotNull(context, "The context may not be null");
-        ensureNotNull(style, "The style may not be null");
-        this.context = context;
-        this.style = style;
-        this.items = new ArrayList<>();
-        this.rawItems = null;
-        this.iconCount = 0;
-        this.dividerCount = 0;
-        this.notifyOnChange = true;
-        this.itemColor = -1;
-        this.dividerColor = -1;
-        setWidth(width);
     }
 
     /**

--- a/library/src/main/java/de/mrapp/android/bottomsheet/view/DraggableView.java
+++ b/library/src/main/java/de/mrapp/android/bottomsheet/view/DraggableView.java
@@ -51,6 +51,81 @@ import static de.mrapp.android.util.DisplayUtil.getDeviceType;
 public class DraggableView extends LinearLayout implements ViewTreeObserver.OnGlobalLayoutListener {
 
     /**
+     * Creates a new root view of a {@link BottomSheet}, which can be dragged by the user.
+     *
+     * @param context
+     *         The context, which should be used by the view, as an instance of the class {@link
+     *         Context}. The context may not be null
+     */
+    public DraggableView(@NonNull final Context context) {
+        super(context);
+        initialize();
+    }
+
+    /**
+     * Creates a new root view of a {@link BottomSheet}, which can be dragged by the user.
+     *
+     * @param context
+     *         The context, which should be used by the view, as an instance of the class {@link
+     *         Context}. The context may not be null
+     * @param attributeSet
+     *         The attribute set, the view's attributes should be obtained from, as an instance of
+     *         the type {@link AttributeSet} or null, if no attributes should be obtained
+     */
+    public DraggableView(@NonNull final Context context,
+                         @Nullable final AttributeSet attributeSet) {
+        super(context, attributeSet);
+        initialize();
+    }
+
+    /**
+     * Creates a new root view of a {@link BottomSheet}, which can be dragged by the user.
+     *
+     * @param context
+     *         The context, which should be used by the view, as an instance of the class {@link
+     *         Context}. The context may not be null
+     * @param attributeSet
+     *         The attribute set, the view's attributes should be obtained from, as an instance of
+     *         the type {@link AttributeSet} or null, if no attributes should be obtained
+     * @param defaultStyle
+     *         The default style to apply to this view. If 0, no style will be applied (beyond what
+     *         is included in the theme). This may either be an attribute resource, whose value will
+     *         be retrieved from the current theme, or an explicit style resource
+     */
+    @TargetApi(Build.VERSION_CODES.HONEYCOMB)
+    public DraggableView(@NonNull final Context context, @Nullable final AttributeSet attributeSet,
+                         @StyleRes final int defaultStyle) {
+        super(context, attributeSet, defaultStyle);
+        initialize();
+    }
+
+    /**
+     * Creates a new root view of a {@link BottomSheet}, which can be dragged by the user.
+     *
+     * @param context
+     *         The context, which should be used by the view, as an instance of the class {@link
+     *         Context}. The context may not be null
+     * @param attributeSet
+     *         The attribute set, the view's attributes should be obtained from, as an instance of
+     *         the type {@link AttributeSet} or null, if no attributes should be obtained
+     * @param defaultStyle
+     *         The default style to apply to this view. If 0, no style will be applied (beyond what
+     *         is included in the theme). This may either be an attribute resource, whose value will
+     *         be retrieved from the current theme, or an explicit style resource
+     * @param defaultStyleResource
+     *         A resource identifier of a style resource that supplies default values for the view,
+     *         used only if the default style is 0 or can not be found in the theme. Can be 0 to not
+     *         look for defaults
+     */
+    @TargetApi(Build.VERSION_CODES.LOLLIPOP)
+    public DraggableView(@NonNull final Context context, @Nullable final AttributeSet attributeSet,
+                         @StyleRes final int defaultStyle,
+                         @StyleRes final int defaultStyleResource) {
+        super(context, attributeSet, defaultStyle, defaultStyleResource);
+        initialize();
+    }
+
+    /**
      * Defines the interface, a class, which should be notified about the view's state, must
      * implement.
      */
@@ -378,81 +453,6 @@ public class DraggableView extends LinearLayout implements ViewTreeObserver.OnGl
         if (callback != null) {
             callback.onHidden(canceled);
         }
-    }
-
-    /**
-     * Creates a new root view of a {@link BottomSheet}, which can be dragged by the user.
-     *
-     * @param context
-     *         The context, which should be used by the view, as an instance of the class {@link
-     *         Context}. The context may not be null
-     */
-    public DraggableView(@NonNull final Context context) {
-        super(context);
-        initialize();
-    }
-
-    /**
-     * Creates a new root view of a {@link BottomSheet}, which can be dragged by the user.
-     *
-     * @param context
-     *         The context, which should be used by the view, as an instance of the class {@link
-     *         Context}. The context may not be null
-     * @param attributeSet
-     *         The attribute set, the view's attributes should be obtained from, as an instance of
-     *         the type {@link AttributeSet} or null, if no attributes should be obtained
-     */
-    public DraggableView(@NonNull final Context context,
-                         @Nullable final AttributeSet attributeSet) {
-        super(context, attributeSet);
-        initialize();
-    }
-
-    /**
-     * Creates a new root view of a {@link BottomSheet}, which can be dragged by the user.
-     *
-     * @param context
-     *         The context, which should be used by the view, as an instance of the class {@link
-     *         Context}. The context may not be null
-     * @param attributeSet
-     *         The attribute set, the view's attributes should be obtained from, as an instance of
-     *         the type {@link AttributeSet} or null, if no attributes should be obtained
-     * @param defaultStyle
-     *         The default style to apply to this view. If 0, no style will be applied (beyond what
-     *         is included in the theme). This may either be an attribute resource, whose value will
-     *         be retrieved from the current theme, or an explicit style resource
-     */
-    @TargetApi(Build.VERSION_CODES.HONEYCOMB)
-    public DraggableView(@NonNull final Context context, @Nullable final AttributeSet attributeSet,
-                         @StyleRes final int defaultStyle) {
-        super(context, attributeSet, defaultStyle);
-        initialize();
-    }
-
-    /**
-     * Creates a new root view of a {@link BottomSheet}, which can be dragged by the user.
-     *
-     * @param context
-     *         The context, which should be used by the view, as an instance of the class {@link
-     *         Context}. The context may not be null
-     * @param attributeSet
-     *         The attribute set, the view's attributes should be obtained from, as an instance of
-     *         the type {@link AttributeSet} or null, if no attributes should be obtained
-     * @param defaultStyle
-     *         The default style to apply to this view. If 0, no style will be applied (beyond what
-     *         is included in the theme). This may either be an attribute resource, whose value will
-     *         be retrieved from the current theme, or an explicit style resource
-     * @param defaultStyleResource
-     *         A resource identifier of a style resource that supplies default values for the view,
-     *         used only if the default style is 0 or can not be found in the theme. Can be 0 to not
-     *         look for defaults
-     */
-    @TargetApi(Build.VERSION_CODES.LOLLIPOP)
-    public DraggableView(@NonNull final Context context, @Nullable final AttributeSet attributeSet,
-                         @StyleRes final int defaultStyle,
-                         @StyleRes final int defaultStyleResource) {
-        super(context, attributeSet, defaultStyle, defaultStyleResource);
-        initialize();
     }
 
     /**


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1213 - The members of an interface declaration or class should appear in a pre-defined order

You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid:S1213

Please let me know if you have any questions.

M-Ezzat
